### PR TITLE
Use the description.name value for user addressible entity name

### DIFF
--- a/custom_components/entsoe/sensor.py
+++ b/custom_components/entsoe/sensor.py
@@ -60,12 +60,16 @@ class EntsoeSensor(CoordinatorEntity, SensorEntity):
     def __init__(self, coordinator: EntsoeCoordinator, description: EntsoeEntityDescription, name: str = "") -> None:
         """Initialize the sensor."""
         if name not in (None, ""):
-            self.entity_id = f"{DOMAIN}.{name}_{description.key}"
+            #The Id used for addressing the entity in the ui, recorder history etc.
+            self.entity_id = f"{DOMAIN}.{name}_{description.name}"
+            #unique id in .storage file for ui configuration.
+            self._attr_unique_id = f"{DOMAIN}.{name}_{description.key}"
         else:
-            self.entity_id = f"{DOMAIN}.{description.key}"
+            self.entity_id = f"{DOMAIN}.{description.name}"
+            self._attr_unique_id = f"entsoe.{description.key}"
 
         self.entity_description: EntsoeEntityDescription = description
-        self._attr_unique_id = f"{self.entity_id}"
+
 
         self._update_job = HassJob(self.async_schedule_update_ha_state)
         self._unsub_update = None


### PR DESCRIPTION
Previously the `entity_id` property was not set causing HA to use the description.name value for the entity names.
Since the description.key value isn't exactly the same as the name property this causes dashboard, history and automation references to no longer work.
By using the description.name value in the entity_id property you will restore the historical data chain as well as prevent users from having to change all entity references after upgrading and re-adding.
#49 