### PR TITLE
have the latest available 48h of data present in the prices attribute

### DIFF
--- a/custom_components/entsoe/coordinator.py
+++ b/custom_components/entsoe/coordinator.py
@@ -93,9 +93,9 @@ class EntsoeCoordinator(DataUpdateCoordinator):
         data = await self.fetch_prices(yesterday, tomorrow)
 
         parsed_data = self.parse_hourprices(data)
-        data_all = parsed_data[-48:].to_dict()
-        data_today = parsed_data[-48:-24].to_dict()
-        data_tomorrow = parsed_data[-24:].to_dict()
+        data_all = parsed_data[-49:].to_dict()
+        data_today = parsed_data[-49:-25].to_dict()
+        data_tomorrow = parsed_data[-25:].to_dict()
 
         return {
             "data": data_all,

--- a/custom_components/entsoe/coordinator.py
+++ b/custom_components/entsoe/coordinator.py
@@ -86,17 +86,16 @@ class EntsoeCoordinator(DataUpdateCoordinator):
         self.logger.debug(self.area)
 
         time_zone = dt.now().tzinfo
-        # We request data for today up until tomorrow.
-        today = pd.Timestamp.now(tz=str(time_zone)).replace(hour=0, minute=0, second=0)
+        # We request data for yesterday up until tomorrow.
+        yesterday = pd.Timestamp.now(tz=str(time_zone)).replace(hour=0, minute=0, second=0) - pd.Timedelta(days = 1)
+        tomorrow = yesterday + pd.Timedelta(days = 3)
 
-        tomorrow = today + pd.Timedelta(hours=47)
-
-        data = await self.fetch_prices(today, tomorrow)
+        data = await self.fetch_prices(yesterday, tomorrow)
 
         parsed_data = self.parse_hourprices(data)
-        data_all = parsed_data.to_dict()
-        data_today = parsed_data[:24].to_dict()
-        data_tomorrow = parsed_data[24:48].to_dict()
+        data_all = parsed_data[-48:].to_dict()
+        data_today = parsed_data[-48:-24].to_dict()
+        data_tomorrow = parsed_data[-24:].to_dict()
 
         return {
             "data": data_all,


### PR DESCRIPTION
As mentioned in #41 having the prices attribute not contain a static amount of data makes it more difficult to create automations.
This PR requests the last 72hours worth of data and selects the newest values to populate the prices(and tomorrow/today) attributes.
Eventually the entity attributes need to be re-examined since (for example) currently there is a lot of duplication in the attributes/across sensors.
Perhaps an issue topic needs to be opened with an help wanted requesting what data people would want to have for automating with the entso-e data.

I could imagine for example that an attribute only containing current and future prices could be handy. (This would have a record removed every hour and at 13:00 get 24 records added).
So that users are easily able to determine when to place a load based on only future pricing.