### PR TITLE
Bugfix updating today and tomorrow lists

### DIFF
--- a/custom_components/entsoe/coordinator.py
+++ b/custom_components/entsoe/coordinator.py
@@ -98,9 +98,13 @@ class EntsoeCoordinator(DataUpdateCoordinator):
         data = await self.fetch_prices(yesterday, tomorrow)
 
         parsed_data = self.parse_hourprices(data)
-        data_all = parsed_data[-49:].to_dict()
-        data_today = parsed_data[-49:-25].to_dict()
-        data_tomorrow = parsed_data[-25:].to_dict()
+        data_all = parsed_data[-48:].to_dict()
+        if parsed_data.size > 48:
+            data_today = parsed_data[-48:-24].to_dict()
+            data_tomorrow = parsed_data[-24:].to_dict()
+        else:
+            data_today = parsed_data[-24:].to_dict()
+            data_tomorrow = {}
 
         return {
             "data": data_all,


### PR DESCRIPTION
Changed how today and tomorrow lists update at midnight. data_tomorrow should be empty between midnight and 14:00 as tomorrows data is not available until 14:00. And data_today should be the last 24 hours of the parsed_data.