### PR TITLE
Ignore all current and future entities from being added to average entity attributes

### DIFF
--- a/custom_components/entsoe/sensor.py
+++ b/custom_components/entsoe/sensor.py
@@ -80,8 +80,10 @@ class EntsoeSensor(CoordinatorEntity, SensorEntity):
             self._attr_native_value = None
         # These return pd.timestamp objects and are therefore not able to get into attributes
         invalid_keys = {"time_min", "time_max"}
+        existing_entities = [type.key for type in SENSOR_TYPES]
         if self.description.key == "avg_price":
-            self._attr_extra_state_attributes = {x: self.coordinator.processed_data()[x] for x in self.coordinator.processed_data() if x not in invalid_keys}
+            self._attr_extra_state_attributes = {x: self.coordinator.processed_data()[x] for x in self.coordinator.processed_data() if x not in invalid_keys and x not in existing_entities}
+
 
         # Cancel the currently scheduled event if there is any
         if self._unsub_update:


### PR DESCRIPTION
As mentioned in #63 the avg sensor attributes contain the entity values of all not explictly omitted entities provided by this integration.
This PR goes through the list and adds to the attribute skip check by excluding all values that are provided by dedicated entities in order to reduce update interval and data duplication.