### PR TITLE
Fix issues arising from E notation pricing by explicitly casting to float

### DIFF
--- a/custom_components/entsoe/coordinator.py
+++ b/custom_components/entsoe/coordinator.py
@@ -76,7 +76,7 @@ class EntsoeCoordinator(DataUpdateCoordinator):
         else:
             template_value = self.modifyer.async_render()
 
-        price = round(template_value * (1 + self.vat), 5)
+        price = round(float(template_value * (1 + self.vat)), 5)
 
         return price
 


### PR DESCRIPTION
Larger floats get returned as:
<img width="1490" alt="Screenshot 2022-11-06 at 14 22 59" src="https://user-images.githubusercontent.com/6717280/200173589-a2babdeb-8de1-436e-83c0-b276ca22025f.png">

This causes the following error:
<img width="968" alt="Screenshot 2022-11-06 at 14 20 15" src="https://user-images.githubusercontent.com/6717280/200173616-cbd54f18-64d5-49ec-a33c-79fd9a4a79a3.png">

Currently we are experiencing this for the dutch region due to some hours pricing having 0.000000E-05 or 8.99999E-x notation.

