### PR TITLE
Return fixed time format to support safari

### DIFF
--- a/custom_components/entsoe/coordinator.py
+++ b/custom_components/entsoe/coordinator.py
@@ -195,8 +195,5 @@ class EntsoeCoordinator(DataUpdateCoordinator):
         return min(hourprices, key=hourprices.get)
 
     def get_timestamped_prices(self, hourprices):
-        list = []
-        for hour, price in hourprices.items():
-            str_hour = str(hour)
-            list.append({"time": str_hour, "price": price})
-        return list
+        return [{"time": hour.strftime('%Y/%m/%d %H:%M:%S'), "price": price} for hour, price in hourprices.items()]
+        


### PR DESCRIPTION
When using the prices from the attribute with the apex chart on apple devices, the graph is not rendered due to a bug in safari: https://github.com/apexcharts/apexcharts.js/issues/702

This makes the time formatting use a fixed format that is supported by safari.

Note that while `%Y/%m/%d %H:%M:%S%a` would add the time zone offset in the string like it is now, it breaks in firefox :man_shrugging: 