### PR TITLE
introduce correct device class for timestamp, set correct timestamp format and introduce state restore functionality

### DIFF
--- a/custom_components/entsoe/coordinator.py
+++ b/custom_components/entsoe/coordinator.py
@@ -54,7 +54,7 @@ class EntsoeCoordinator(DataUpdateCoordinator):
             hass,
             logger,
             name="ENTSO-e coordinator",
-            update_interval=timedelta(minutes=60),
+            update_interval=timedelta(seconds=60),
         )
 
     def calc_price(self, value, fake_dt=None, no_template=False) -> float:
@@ -98,7 +98,6 @@ class EntsoeCoordinator(DataUpdateCoordinator):
         tomorrow = yesterday + pd.Timedelta(hours = 71)
 
         data = await self.fetch_prices(yesterday, tomorrow)
-        self.logger.debug(data)
         if data is not None:
             parsed_data = self.parse_hourprices(data)
             data_all = parsed_data[-48:].to_dict()
@@ -114,6 +113,7 @@ class EntsoeCoordinator(DataUpdateCoordinator):
                 "dataToday": data_today,
                 "dataTomorrow": data_tomorrow,
             }
+            #TODO test if this is even necessary
         elif self.data is not None:
             self.logger.debug(self.data)
             self.logger.debug("returning self data")

--- a/custom_components/entsoe/coordinator.py
+++ b/custom_components/entsoe/coordinator.py
@@ -150,10 +150,9 @@ class EntsoeCoordinator(DataUpdateCoordinator):
                     self.logger.warning(f"Warning the integration is running in degraded mode (falling back on stored data) since fetching the latest ENTSOE-e prices failed with exception: {exc}.")
                 else:
                     self.logger.error(f"Error the latest available data is older than the current time. Therefore entities will no longer update. {exc}")
+                    raise UpdateFailed(f"Unexcpected error when fetching ENTSO-e prices: {exc}") from exc
             else:
                 self.logger.warning(f"Warning the integration doesn't have any up to date local data this means that entities won't get updated but access remains to restorable entities: {exc}.")
-
-#            raise UpdateFailed(f"Unexcpected error when fetching ENTSO-e prices: {exc}") from exc
 
 
 

--- a/custom_components/entsoe/coordinator.py
+++ b/custom_components/entsoe/coordinator.py
@@ -54,7 +54,7 @@ class EntsoeCoordinator(DataUpdateCoordinator):
             hass,
             logger,
             name="ENTSO-e coordinator",
-            update_interval=timedelta(seconds=60),
+            update_interval=timedelta(minutes=60),
         )
 
     def calc_price(self, value, fake_dt=None, no_template=False) -> float:

--- a/custom_components/entsoe/sensor.py
+++ b/custom_components/entsoe/sensor.py
@@ -122,9 +122,9 @@ class EntsoeSensor(CoordinatorEntity, RestoreSensor):
                 value = value.to_pydatetime()
 
             self._attr_native_value = value
-        except (TypeError, IndexError):
+        except Exception as exc:
             # No data available
-            _LOGGER.warning(f"Unable to update entity due to data processing error: {value}")
+            _LOGGER.warning(f"Unable to update entity due to data processing error: {value} and error: {exc}")
 
         # These return pd.timestamp objects and are therefore not able to get into attributes
         invalid_keys = {"time_min", "time_max"}

--- a/custom_components/entsoe/sensor.py
+++ b/custom_components/entsoe/sensor.py
@@ -171,7 +171,7 @@ class EntsoeSensor(CoordinatorEntity, RestoreSensor):
             data_today = {  pd.Timestamp(item["time"]) : item["price"] for item in attributes.get("prices")[-48:-24] }
             data_tomorrow = {  pd.Timestamp(item["time"]) : item["price"] for item in attributes.get("prices")[-24:] }
         else:
-            data_today = {  pd.Timestamp(item["time"]) : item["price"] for item in attributes.get("prices")[-24:]} #new_state.attributes.get("prices")[-24:].to_dict()
+            data_today = {  pd.Timestamp(item["time"]) : item["price"] for item in attributes.get("prices")[-24:]}
             data_tomorrow = {}
         return {
             "data": data_all,

--- a/custom_components/entsoe/sensor.py
+++ b/custom_components/entsoe/sensor.py
@@ -127,7 +127,7 @@ class EntsoeSensor(CoordinatorEntity, RestoreSensor):
         # These return pd.timestamp objects and are therefore not able to get into attributes
         invalid_keys = {"time_min", "time_max"}
         existing_entities = [type.key for type in SENSOR_TYPES]
-        if self.description.key == "avg_price":
+        if self.description.key == "avg_price" and self._attr_native_value is not None:
             self._attr_extra_state_attributes = {x: self.coordinator.processed_data()[x] for x in self.coordinator.processed_data() if x not in invalid_keys and x not in existing_entities}
 
 


### PR DESCRIPTION
This PR introduces the restore state functionality ([see](https://developers.home-assistant.io/docs/core/entity/sensor?_highlight=restore#restoring-sensor-states)) for the entsoe integrations entities.
This was discussed in #86 and mentioned in #94 

It is also forced to fix #93 and #64 since otherwise the data restored would be the string representation of the PD timestamp class.
Which is currently unusable for automating whithin homeassistant.
This PR has been tested locally (by triggering entsoe errors and waiting for updates).
Furthermore, this PR was also tested by updating a live instance which went without any issues.

fixes #93, fixes #94, fixes #64, fixes #86