### PR TITLE
Change input selector for the template config

### DIFF
--- a/custom_components/entsoe/config_flow.py
+++ b/custom_components/entsoe/config_flow.py
@@ -15,6 +15,8 @@ from homeassistant.helpers.selector import (
     SelectSelectorConfig,
     SelectSelector,
     SelectOptionDict,
+    TemplateSelectorConfig,
+    TemplateSelector,
 )
 from homeassistant.helpers.template import Template
 
@@ -182,7 +184,7 @@ class EntsoeFlowHandler(ConfigFlow, domain=DOMAIN):
                     vol.Optional(
                         CONF_VAT_VALUE, default=AREA_INFO[self.area]["VAT"]
                     ): vol.All(vol.Coerce(float, "must be a number")),
-                    vol.Optional(CONF_MODIFYER, default=""): vol.All(vol.Coerce(str)),
+                    vol.Optional(CONF_MODIFYER, default=""): TemplateSelector(TemplateSelectorConfig()),
                     vol.Optional(CONF_CALCULATION_MODE, default=CALCULATION_MODE["default"]): SelectSelector(
                         SelectSelectorConfig(
                             options=[
@@ -274,7 +276,7 @@ class EntsoeOptionFlowHandler(OptionsFlow):
                     ): vol.All(vol.Coerce(float, "must be a number")),
                     vol.Optional(
                         CONF_MODIFYER, default=self.config_entry.options[CONF_MODIFYER]
-                    ): vol.All(vol.Coerce(str)),
+                    ):  TemplateSelector(TemplateSelectorConfig()),
                     vol.Optional(CONF_CALCULATION_MODE, default=calculation_mode_default ): SelectSelector(
                         SelectSelectorConfig(
                             options=[


### PR DESCRIPTION
The input field for the "Price Modifier Template" is not very well suited for inputting a multi line template, as mentioned in #18 f.ex.

This patch changes the selector for that field to `TemplateSelector` which allows multi line template inputs.

Fixes #18.