### PR TITLE
Custom currency

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ Search for "ENTSO-e" when adding HACS integrations and add "ENTSO-e Transparency
 ------
 ## Configuration
 
-The sensors can be added using the web UI. In the web UI you can add your API-key and country and the sensors will automatically be added to your system. There is an optional field for an cost modifyer template.
+The sensors can be added using the web UI. In the web UI you can add your API-key and country and the sensors will automatically be added to your system. There is an optional field for a cost modifyer template and resulting currency.
 
 ### Cost Modifyer Template
 
-In the optional field `Price Modifyer Template` a template to modify the price to add additional costs, such as fixed costs per kWh and VAT, can be added. When left empty, no additional costs are added.
+In the optional field `Price Modifyer Template` a template to modify the price to add additional costs (such as fixed costs per kWh and VAT) and currency conversion (based on a currency sensor) can be specified. When left empty, no additional costs are added.
 In this template `now()` always refers start of the hour of that price and `current_price` refers to the price itself. This way day ahead price can be modified to correct for extra costs.
 
 An example template is given below. You can find and share other templates [here](https://github.com/JaccoR/hass-entso-e/discussions/categories/price-modifyer-templates).

--- a/custom_components/entsoe/const.py
+++ b/custom_components/entsoe/const.py
@@ -1,15 +1,4 @@
-from __future__ import annotations
-
-from dataclasses import dataclass
-from collections.abc import Callable
-
-from homeassistant.components.sensor import SensorEntityDescription, SensorDeviceClass, SensorStateClass
-from homeassistant.const import (
-    CURRENCY_EURO,
-    PERCENTAGE,
-    UnitOfEnergy,
-)
-from homeassistant.helpers.typing import StateType
+from homeassistant.const import CURRENCY_EURO
 
 ATTRIBUTION = "Data provided by ENTSO-e Transparency Platform"
 DOMAIN = "entsoe"
@@ -22,11 +11,13 @@ CONF_ENTITY_NAME = "name"
 CONF_AREA = "area"
 CONF_COORDINATOR = "coordinator"
 CONF_MODIFYER = "modifyer"
+CONF_CURRENCY = "currency"
 CONF_ADVANCED_OPTIONS = "advanced_options"
 CONF_CALCULATION_MODE = "calculation_mode"
 CONF_VAT_VALUE = "VAT_value"
 
 DEFAULT_MODIFYER = "{{current_price}}"
+DEFAULT_CURRENCY = CURRENCY_EURO
 
 #default is only for internal use / backwards compatibility
 CALCULATION_MODE = { "default": "publish", "rotation": "rotation", "sliding": "sliding", "publish": "publish" }
@@ -87,65 +78,3 @@ AREA_INFO = {"AT":{"code":"AT", "name":"Austria", "VAT":0.21, "Currency":"EUR"},
             #  "TR":{"code":"TR", "name":"Turkey", "VAT":0.21, "Currency":"EUR"},
             #  "UA":{"code":"UA", "name":"Ukraine", "VAT":0.21, "Currency":"EUR"},
             }
-
-@dataclass
-class EntsoeEntityDescription(SensorEntityDescription):
-    """Describes ENTSO-e sensor entity."""
-
-    value_fn: Callable[[dict], StateType] = None
-
-
-SENSOR_TYPES: tuple[EntsoeEntityDescription, ...] = (
-    EntsoeEntityDescription(
-        key="current_price",
-        name="Current electricity market price",
-        native_unit_of_measurement=f"{CURRENCY_EURO}/{UnitOfEnergy.KILO_WATT_HOUR}",
-        value_fn=lambda data: data["current_price"],
-        state_class=SensorStateClass.MEASUREMENT
-    ),
-    EntsoeEntityDescription(
-        key="next_hour_price",
-        name="Next hour electricity market price",
-        native_unit_of_measurement=f"{CURRENCY_EURO}/{UnitOfEnergy.KILO_WATT_HOUR}",
-        value_fn=lambda data: data["next_hour_price"],
-    ),
-    EntsoeEntityDescription(
-        key="min_price",
-        name="Lowest energy price today",
-        native_unit_of_measurement=f"{CURRENCY_EURO}/{UnitOfEnergy.KILO_WATT_HOUR}",
-        value_fn=lambda data: data["min_price"],
-    ),
-    EntsoeEntityDescription(
-        key="max_price",
-        name="Highest energy price today",
-        native_unit_of_measurement=f"{CURRENCY_EURO}/{UnitOfEnergy.KILO_WATT_HOUR}",
-        value_fn=lambda data: data["max_price"],
-    ),
-    EntsoeEntityDescription(
-        key="avg_price",
-        name="Average electricity price today",
-        native_unit_of_measurement=f"{CURRENCY_EURO}/{UnitOfEnergy.KILO_WATT_HOUR}",
-        value_fn=lambda data: data["avg_price"],
-    ),
-    EntsoeEntityDescription(
-        key="percentage_of_max",
-        name="Current percentage of highest electricity price today",
-        native_unit_of_measurement=f"{PERCENTAGE}",
-        icon="mdi:percent",
-        value_fn=lambda data: round(
-            data["current_price"] / data["max_price"] * 100, 1
-        ),
-    ),
-    EntsoeEntityDescription(
-        key="highest_price_time_today",
-        name="Time of highest price today",
-        device_class=SensorDeviceClass.TIMESTAMP,
-        value_fn=lambda data: data["time_max"],
-    ),
-    EntsoeEntityDescription(
-        key="lowest_price_time_today",
-        name="Time of lowest price today",
-        device_class=SensorDeviceClass.TIMESTAMP,
-        value_fn=lambda data: data["time_min"],
-    ),
-)

--- a/custom_components/entsoe/sensor.py
+++ b/custom_components/entsoe/sensor.py
@@ -12,7 +12,7 @@ import pandas as pd
 from homeassistant.components.sensor import DOMAIN, RestoreSensor, SensorDeviceClass, SensorEntityDescription, SensorExtraStoredData, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    CURRENCY_EURO,
+    CONF_CURRENCY,
     PERCENTAGE,
     UnitOfEnergy,
 )
@@ -22,7 +22,7 @@ from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import utcnow
-from .const import ATTRIBUTION, CONF_COORDINATOR, CONF_ENTITY_NAME, DOMAIN, ICON, SENSOR_TYPES
+from .const import ATTRIBUTION, CONF_COORDINATOR, CONF_ENTITY_NAME, DOMAIN, ICON
 from .coordinator import EntsoeCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -202,7 +202,8 @@ class EntsoeSensor(CoordinatorEntity, RestoreSensor):
 
         # These return pd.timestamp objects and are therefore not able to get into attributes
         invalid_keys = {"time_min", "time_max"}
-        existing_entities = [type.key for type in SENSOR_TYPES]
+        # Currency is immaterial to the entity key
+        existing_entities = [type.key for type in sensor_descriptions(currency = "")]
         if self.description.key == "avg_price" and self._attr_native_value is not None:
             self._attr_extra_state_attributes = {x: self.coordinator.processed_data()[x] for x in self.coordinator.processed_data() if x not in invalid_keys and x not in existing_entities}
 

--- a/custom_components/entsoe/translations/en.json
+++ b/custom_components/entsoe/translations/en.json
@@ -8,14 +8,15 @@
             "area": "Area*",
             "advanced_options": "I want to set VAT, template and calculation method (next step)",
             "modifyer": "Price Modifyer Template (Optional)",
+            "currency": "Currency of the modified price (Optional)",
             "name": "Name (Optional)"
           }
       },
       "extra": {
         "data":{
           "VAT_value": "VAT tariff",
-          "modifyer": "Price Modifyer Template (Optional)"
-
+          "modifyer": "Price Modifyer Template (Optional)",
+          "currency": "Currency of the modified price (Optional)"
         }
       }
     },
@@ -33,6 +34,7 @@
           "api_key": "Your API Key",
           "area": "Area*",
           "modifyer": "Price Modifyer Template (Optional)",
+          "currency": "Currency of the modified price (Optional)",
           "VAT_value": "VAT tariff",
           "name": "Name (Optional)"
         }


### PR DESCRIPTION
Add an option to set the currency of the (modified) value.

Will only affect the unit of measurement for the computed prices, and does not perform the actual conversion.

Conversion must be manually added to the `modifyer` template using a currency exchange sensor.