### PR TITLE
Remove unnecessary call to template.attach

### DIFF
--- a/custom_components/entsoe/coordinator.py
+++ b/custom_components/entsoe/coordinator.py
@@ -17,7 +17,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.template import Template, attach
+from homeassistant.helpers.template import Template
 from jinja2 import pass_context
 
 from .const import DEFAULT_MODIFYER, AREA_INFO, CALCULATION_MODE
@@ -46,8 +46,6 @@ class EntsoeCoordinator(DataUpdateCoordinator):
         else:
             if self.modifyer.template in ("", None):
                 self.modifyer = cv.template(DEFAULT_MODIFYER)
-
-        attach(self.hass, self.modifyer)
 
         logger = logging.getLogger(__name__)
         super().__init__(


### PR DESCRIPTION
Remove unnecessary call to `template.attach`

Since Home Assistant Core 2023.4 it's no longer needed to call `template.attach` : https://github.com/home-assistant/core/pull/89242

Note: I have not tested the change, the PR is created in preparation for removing the `template.attach` function from Home Assistant Core because it no longer serves any purpose.