### PR TITLE
Reduce the number of filtering events when sensors try to update data

### DIFF
--- a/custom_components/entsoe/const.py
+++ b/custom_components/entsoe/const.py
@@ -21,10 +21,13 @@ DEFAULT_ENERGY_SCALE = "kWh"
 
 # default is only for internal use / backwards compatibility
 CALCULATION_MODE = {
-    "default": "publish",
-    "rotation": "rotation",
-    "sliding": "sliding",
-    "publish": "publish",
+    "default":      "publish",
+    "publish":      "publish",       
+    "daily":        "daily",         
+    "sliding":      "sliding",       
+    "sliding-12":   "sliding-12",   # new half day sliding
+    "forecast":     "forecast",     # 24hrs forward looking
+    "forecast-12":  "forecast-12",  # 12hrs forward looking
 }
 
 ENERGY_SCALES = { "kWh": 1000, "MWh": 1 }

--- a/custom_components/entsoe/const.py
+++ b/custom_components/entsoe/const.py
@@ -26,8 +26,8 @@ CALCULATION_MODE = {
     "daily":        "daily",         
     "sliding":      "sliding",       
     "sliding-12":   "sliding-12",   # new half day sliding
-    "forecast":     "forecast",     # 24hrs forward looking
-    "forecast-12":  "forecast-12",  # 12hrs forward looking
+    "forward":      "forward",     # 24hrs forward looking
+    "forward-12":   "forward-12",  # 12hrs forward looking
 }
 
 ENERGY_SCALES = { "kWh": 1000, "MWh": 1 }

--- a/custom_components/entsoe/coordinator.py
+++ b/custom_components/entsoe/coordinator.py
@@ -214,16 +214,16 @@ class EntsoeCoordinator(DataUpdateCoordinator):
             self.logger.debug(f"Filter dataset to surrounding 12hrs {start} - {end} -> refresh each hour")
             return {hour: price for hour, price in data.items() if start < hour < end }
 
-        elif self.calculation_mode == CALCULATION_MODE["forecast"]:
+        elif self.calculation_mode == CALCULATION_MODE["forward"]:
             start = dt.now().replace(minute=0, second=0, microsecond=0)
             end = start + timedelta(hours=24)
             self.logger.debug(f"Filter dataset to upcomming 24hrs {start} - {end} -> refresh each hour")
             return {hour: price for hour, price in data.items() if start < hour < end }
         
-        elif self.calculation_mode == CALCULATION_MODE["forecast-12"]:
+        elif self.calculation_mode == CALCULATION_MODE["forward-12"]:
             start = dt.now().replace(minute=0, second=0, microsecond=0)
             end = start + timedelta(hours=12)
-            self.logger.debug(f"Filter dataset to upcomming 24hrs {start} - {end} -> refresh each hour")
+            self.logger.debug(f"Filter dataset to upcomming 12hrs {start} - {end} -> refresh each hour")
             return {hour: price for hour, price in data.items() if start < hour < end }
         
         # default elif self.calculation_mode == CALCULATION_MODE["publish"]:

--- a/custom_components/entsoe/coordinator.py
+++ b/custom_components/entsoe/coordinator.py
@@ -121,7 +121,8 @@ class EntsoeCoordinator(DataUpdateCoordinator):
             self.data = parsed_data
             self.filtered_hourprices = self._filter_calculated_hourprices(parsed_data)
             return parsed_data
-
+    
+    # fetching of new data is needed when (1) we have no data, (2) when todays data is below 20 hrs or (3) tomorrows data is below 20hrs and its after 11
     def check_update_needed(self, now):
         if self.data is None:
             return True
@@ -178,6 +179,7 @@ class EntsoeCoordinator(DataUpdateCoordinator):
             }
         return self.parse_hourprices(await self.fetch_prices(start_date, end_date))
 
+    # TODO: this method is called by each sensor, each hour. Change the code so only the first will update 
     def update_data(self):
         now = dt.now()
         if self.today.date() != now.date():
@@ -190,27 +192,43 @@ class EntsoeCoordinator(DataUpdateCoordinator):
         return len(self.get_data_today()) > MIN_HOURS
 
     def _filter_calculated_hourprices(self, data):
-        # rotation = calculations made upon 24hrs today
-        if self.calculation_mode == CALCULATION_MODE["rotation"]:
+        if self.calculation_mode == CALCULATION_MODE["daily"]:
+            self.logger.debug(f"Filter dataset for prices today -> refresh each day")
             return {
                 hour: price
                 for hour, price in data.items()
                 if hour >= self.today and hour < self.today + timedelta(days=1)
             }
-        # sliding = calculations made on all data from the current hour and beyond (future data only)
+        
         elif self.calculation_mode == CALCULATION_MODE["sliding"]:
-            now = dt.now().replace(minute=0, second=0, microsecond=0)
-            return {hour: price for hour, price in data.items() if hour >= now}
-        # publish >48 hrs of data = calculations made on all data of today and tomorrow (48 hrs)
-        elif self.calculation_mode == CALCULATION_MODE["publish"] and len(data) > 48:
-            return {hour: price for hour, price in data.items() if hour >= self.today}
-        # publish <=48 hrs of data = calculations made on all data of yesterday and today (48 hrs) 
-        elif self.calculation_mode == CALCULATION_MODE["publish"]:
-            return {
-                hour: price
-                for hour, price in data.items()
-                if hour >= self.today - timedelta(days=1)
-            }
+            start = dt.now().replace(minute=0, second=0, microsecond=0)
+            start -= timedelta(hours=12)
+            end = start + timedelta(hours=24)
+            self.logger.debug(f"Filter dataset to surrounding 24hrs {start} - {end} -> refresh each hour")
+            return {hour: price for hour, price in data.items() if start < hour < end }
+        
+        elif self.calculation_mode == CALCULATION_MODE["sliding-12"]:
+            start = dt.now().replace(minute=0, second=0, microsecond=0)
+            start -= timedelta(hours=6)
+            end = start + timedelta(hours=12)
+            self.logger.debug(f"Filter dataset to surrounding 12hrs {start} - {end} -> refresh each hour")
+            return {hour: price for hour, price in data.items() if start < hour < end }
+
+        elif self.calculation_mode == CALCULATION_MODE["forecast"]:
+            start = dt.now().replace(minute=0, second=0, microsecond=0)
+            end = start + timedelta(hours=24)
+            self.logger.debug(f"Filter dataset to upcomming 24hrs {start} - {end} -> refresh each hour")
+            return {hour: price for hour, price in data.items() if start < hour < end }
+        
+        elif self.calculation_mode == CALCULATION_MODE["forecast-12"]:
+            start = dt.now().replace(minute=0, second=0, microsecond=0)
+            end = start + timedelta(hours=12)
+            self.logger.debug(f"Filter dataset to upcomming 24hrs {start} - {end} -> refresh each hour")
+            return {hour: price for hour, price in data.items() if start < hour < end }
+        
+        # default elif self.calculation_mode == CALCULATION_MODE["publish"]:
+        self.logger.debug(f"Do not filter the dataset, use the complete dataset as fetched")
+        return { hour: price for hour, price in data.items() }
 
     def get_prices_today(self):
         return self.get_timestamped_prices(self.get_data_today())


### PR DESCRIPTION
The coordinator is called each 60 minutes to refresh its data. However when the sensors try to get the latest data the calculator may not be refreshed. 

I call the calculator the logic which filters the data based on the calculation_mode, and uses this dataset to calculate the min(), max(), avg(), perc()

I change the update_data() to sync_calculator() to be more descriptive and added a self.calculator_last_sync member which tracks the hour for which the calculator was last updated

This codes optimizes update #188 
