### PR TITLE
Price modifier should revert to default template when submitted empty

### DIFF
--- a/custom_components/entsoe/config_flow.py
+++ b/custom_components/entsoe/config_flow.py
@@ -313,7 +313,8 @@ class EntsoeOptionFlowHandler(OptionsFlow):
                     ): vol.All(vol.Coerce(float, "must be a number")),
                     vol.Optional(
                         CONF_MODIFYER,
-                        default=self.config_entry.options[CONF_MODIFYER],
+                        description={"suggested_value": self.config_entry.options[CONF_MODIFYER]},
+                        default=DEFAULT_MODIFYER,
                     ): TemplateSelector(TemplateSelectorConfig()),
                     vol.Optional(
                         CONF_CURRENCY,


### PR DESCRIPTION
Currently when the user submits an empty `CONF_MODIFYER` Home Assistant will send the `default`, which is the previous entry. So users are unable to clear / reset the field.

This will pre-fill the value that was already present in the field, but when a user clears the field it will send the actual default template `{{current_price}}`.