### PR TITLE
Fix entity id generation

### DIFF
--- a/custom_components/entsoe/sensor.py
+++ b/custom_components/entsoe/sensor.py
@@ -172,14 +172,16 @@ class EntsoeSensor(CoordinatorEntity, RestoreSensor):
         self.description = description
         self.last_update_success = True
 
-        name_prefix = ""
         if name not in (None, ""):
-            name_prefix = f"{slugify(name)}_"
-        # The Id used for addressing the entity in the ui, recorder history etc.
-        self.entity_id = f"{DOMAIN}.{name_prefix}{slugify(description.name)}"
-        # unique id in .storage file for ui configuration.
-        self._attr_unique_id = f"entsoe.{name_prefix}{description.key}"
-        self._attr_name = f"{description.name}"
+            # The Id used for addressing the entity in the ui, recorder history etc.
+            self.entity_id = f"{DOMAIN}.{slugify(name)}_{slugify(description.name)}"
+            # unique id in .storage file for ui configuration.
+            self._attr_unique_id = f"entsoe.{slugify(name)}_{description.key}"
+            self._attr_name = f"{description.name} ({name})"
+        else:
+            self.entity_id = f"{DOMAIN}.{slugify(description.name)}"
+            self._attr_unique_id = f"entsoe.{description.key}"
+            self._attr_name = f"{description.name}"
 
         self.entity_description: EntsoeEntityDescription = description
         self._attr_icon = description.icon

--- a/custom_components/entsoe/sensor.py
+++ b/custom_components/entsoe/sensor.py
@@ -22,7 +22,7 @@ from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.util import utcnow
+from homeassistant.util import utcnow, slugify
 
 from .utils import bucket_time
 from .const import (
@@ -172,16 +172,14 @@ class EntsoeSensor(CoordinatorEntity, RestoreSensor):
         self.description = description
         self.last_update_success = True
 
+        name_prefix = ""
         if name not in (None, ""):
-            # The Id used for addressing the entity in the ui, recorder history etc.
-            self.entity_id = f"{DOMAIN}.{name}_{description.name}"
-            # unique id in .storage file for ui configuration.
-            self._attr_unique_id = f"entsoe.{name}_{description.key}"
-            self._attr_name = f"{description.name} ({name})"
-        else:
-            self.entity_id = f"{DOMAIN}.{description.name}"
-            self._attr_unique_id = f"entsoe.{description.key}"
-            self._attr_name = f"{description.name}"
+            name_prefix = f"{slugify(name)}_"
+        # The Id used for addressing the entity in the ui, recorder history etc.
+        self.entity_id = f"{DOMAIN}.{name_prefix}{slugify(description.name)}"
+        # unique id in .storage file for ui configuration.
+        self._attr_unique_id = f"entsoe.{name_prefix}{description.key}"
+        self._attr_name = f"{description.name}"
 
         self.entity_description: EntsoeEntityDescription = description
         self._attr_icon = description.icon

--- a/custom_components/entsoe/translations/en.json
+++ b/custom_components/entsoe/translations/en.json
@@ -23,8 +23,8 @@
       }
     },
     "error": {
-      "invalid_template": "Invalid template, check https://github.com/JaccoR/hass-entso-e",
-      "missing_current_price": "'current_price' is missing from the template, check https://github.com/JaccoR/hass-entso-e",
+      "invalid_template": "Invalid template",
+      "missing_current_price": "'current_price' is missing from the template",
       "already_configured": "Integration instance with the same name already exists"
     }
   },
@@ -44,8 +44,8 @@
       }
     },
     "error": {
-      "invalid_template": "Invalid Template, Check https://github.com/JaccoR/hass-entso-e",
-      "missing_current_price": "'current_price' is missing from the template, check https://github.com/JaccoR/hass-entso-e",
+      "invalid_template": "Invalid Template",
+      "missing_current_price": "'current_price' is missing from the template",
       "already_configured": "Integration instance with the same name already exists"
     }
   },


### PR DESCRIPTION
The entity ids could generate spaces, which is not allowed anymore in Home Assistant 2026.2. 

Fixes #283 
Fixes #281 