### PR TITLE
Prevent re-creation of entities

### DIFF
--- a/custom_components/entsoe/sensor.py
+++ b/custom_components/entsoe/sensor.py
@@ -176,7 +176,7 @@ class EntsoeSensor(CoordinatorEntity, RestoreSensor):
             # The Id used for addressing the entity in the ui, recorder history etc.
             self.entity_id = f"{DOMAIN}.{slugify(name)}_{slugify(description.name)}"
             # unique id in .storage file for ui configuration.
-            self._attr_unique_id = f"entsoe.{slugify(name)}_{description.key}"
+            self._attr_unique_id = f"entsoe.{name}_{description.key}"
             self._attr_name = f"{description.name} ({name})"
         else:
             self.entity_id = f"{DOMAIN}.{slugify(description.name)}"


### PR DESCRIPTION
We can prevent the re-creation of entities by rolling back the `_attr_unique_id`, which is still allowed to contain spaces. For everyone already upgraded to 0.7.3 this is going to do another entity change unfortunately. 