### PR TITLE
fix: replace threading.Lock with asyncio.Lock to prevent event loop blocking

### DIFF
--- a/custom_components/entsoe/coordinator.py
+++ b/custom_components/entsoe/coordinator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-import threading
+import asyncio
 from datetime import timedelta
 from functools import cached_property
 
@@ -51,7 +51,7 @@ class EntsoeCoordinator(DataUpdateCoordinator):
         self.vat = VAT
         self.calculator_last_sync = None
         self.filtered_hourprices = []
-        self.lock = threading.Lock()
+        self.lock = asyncio.Lock()
 
         # Check incase the sensor was setup using config flow.
         # This blow up if the template isnt valid.
@@ -248,7 +248,7 @@ class EntsoeCoordinator(DataUpdateCoordinator):
     async def sync_calculator(self):
         now = dt.now()
         bucket = self.current_bucket_time
-        with self.lock:
+        async with self.lock:
             if (
                 self.calculator_last_sync is None
                 or self.calculator_last_sync != bucket


### PR DESCRIPTION
## Problem

When the ENTSO-e API is slow or unresponsive, Home Assistant becomes completely frozen and unresponsive. This has been reported multiple times in #292 and #291.

## Root Cause

The coordinator uses `threading.Lock()` in async code:

```python
self.lock = threading.Lock()
# ...
with self.lock:
```

A `threading.Lock()` in async code **blocks the entire event loop** when waiting to acquire the lock. This is a classic asyncio antipattern that causes deadlocks.

## Solution

Replace with `asyncio.Lock()`, which is the correct primitive for async code:

```python
self.lock = asyncio.Lock()
# ...
async with self.lock:
```

`asyncio.Lock()` yields control back to the event loop while waiting, allowing other tasks (like the HA web interface) to continue running.

## Testing

- ✅ Tested on Home Assistant 2026.2.2
- ✅ HA starts up normally even when ENTSO-e API is unavailable
- ✅ No more frozen/unresponsive Home Assistant
- ✅ Sensors show 'unavailable' gracefully when API is down

Fixes #292