### PR TITLE
Add aiohttp request timeouts and remove unused requests dependency

### DIFF
--- a/custom_components/entsoe/api_client.py
+++ b/custom_components/entsoe/api_client.py
@@ -7,10 +7,11 @@ from collections import defaultdict
 from datetime import datetime, timedelta
 from typing import Dict, Union
 
+import asyncio
+
 import aiohttp
 import pytz
-import requests
-from aiohttp import ClientResponse, ClientError
+from aiohttp import ClientError
 
 from custom_components.entsoe.const import DEFAULT_PERIOD
 from custom_components.entsoe.utils import get_interval_minutes
@@ -42,16 +43,19 @@ class EntsoeClient:
         }
         params.update(base_params)
 
+        timeout = aiohttp.ClientTimeout(total=10, connect=5)
+        last_error = None
         for url in API_URLS:
             _LOGGER.debug(f"Performing request to {url} with params {params}")
-            async with aiohttp.ClientSession() as session:
-                try:
+            try:
+                async with aiohttp.ClientSession(timeout=timeout) as session:
                     return await session.get(url=url, params=params, raise_for_status=True)
-                except ClientError as e:
-                    _LOGGER.info(e)
-                    continue
+            except (ClientError, asyncio.TimeoutError) as e:
+                last_error = e
+                _LOGGER.info(f"ENTSO-e request to {url} failed: {e}")
+                continue
 
-        raise EntsoeException("All ENTSO-e API endpoints failed to respond with status 200.")
+        raise EntsoeException(f"All ENTSO-e API endpoints failed: {last_error}")
 
     def _remove_namespace(self, tree):
         """Remove namespaces in the passed XML tree for easier tag searching."""

--- a/custom_components/entsoe/manifest.json
+++ b/custom_components/entsoe/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://github.com/JaccoR/hass-entso-e",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/JaccoR/hass-entso-e/issues",
-  "requirements": ["requests"],
+  "requirements": [],
   "version": "0.7.1"
 }


### PR DESCRIPTION
## Summary
- Add `ClientTimeout(total=10, connect=5)` to aiohttp sessions — without this, each request uses aiohttp's default 300s timeout, meaning an unreachable API hangs for 5+ minutes per URL (10 min total with both endpoints)
- Catch `asyncio.TimeoutError` alongside `ClientError` so timeouts gracefully fall through to the next API URL instead of raising an unhandled exception
- Remove unused `requests` import and `requests` from manifest requirements (only `aiohttp` is used)

Complements #293 and #294 — those fix the event loop blocking (`threading.Lock` → `asyncio.Lock`) and response lifecycle, while this adds the missing request-level timeouts.

Fixes #263

## Test plan
- [ ] Verify HA starts normally when ENTSO-e API is reachable
- [ ] Verify HA starts normally when ENTSO-e API is unreachable (should fail fast within ~20s instead of hanging)
- [ ] Verify degraded mode works when API goes down after initial data load