### PR TITLE
feat: track raw spot prices and expose them as sensors and chart data

### DIFF
--- a/custom_components/entsoe/coordinator.py
+++ b/custom_components/entsoe/coordinator.py
@@ -53,6 +53,7 @@ class EntsoeCoordinator(DataUpdateCoordinator):
         self.filtered_hourprices = []
         self.lock = asyncio.Lock()
         self._last_cleanup_date = None
+        self.raw_hourprices = {}
 
         # Check incase the sensor was setup using config flow.
         # This blow up if the template isnt valid.
@@ -137,6 +138,7 @@ class EntsoeCoordinator(DataUpdateCoordinator):
                 # Degraded mode returned cached data; don't re-parse already-processed prices
                 self.logger.debug("Using cached data from degraded mode")
                 return data
+            self.raw_hourprices = {k: round(v / ENERGY_SCALES[self.energy_scale], 5) for k, v in data.items()}
             parsed_data = self.parse_hourprices(data)
             self.logger.debug(
                 f"received pricing data from entso-e for {len(data)} hours"
@@ -218,13 +220,16 @@ class EntsoeCoordinator(DataUpdateCoordinator):
     # SENSOR: Get the current price
     def get_current_price(self) -> float | None:
         return self.data.get(self.current_bucket_time)
+    
+    # SENSOR: Get the current raw (unmodified) price in kWh
+    def get_current_raw_price(self) -> float | None:
+        return self.raw_hourprices.get(self.current_bucket_time)
 
     # SENSOR: Get the next hour price
     def get_next_price(self) -> float | None:
         return self.data.get(
             self.current_bucket_time + timedelta(minutes=self.period_minutes)
         )
-
     # SENSOR: Get timestamped prices of today as attribute for Average Sensor
     def get_prices_today(self):
         return self.get_timestamped_prices(self.get_data_today())
@@ -252,7 +257,8 @@ class EntsoeCoordinator(DataUpdateCoordinator):
         list = []
         for hour, price in hourprices.items():
             str_hour = str(hour)
-            list.append({"time": str_hour, "price": price})
+            entry = {"time": str_hour, "spot_price": self.raw_hourprices.get(hour), "price": price}
+            list.append(entry)
         return list
 
     # --------------------------------------------------------------------------------------------------------------------------------
@@ -290,6 +296,12 @@ class EntsoeCoordinator(DataUpdateCoordinator):
                     self.data = {
                         hour: price
                         for hour, price in self.data.items()
+                        if hour >= self.today - timedelta(days=1)
+                    }
+
+                    self.raw_hourprices = {
+                        hour: price
+                        for hour, price in self.raw_hourprices.items()
                         if hour >= self.today - timedelta(days=1)
                     }
 
@@ -413,4 +425,10 @@ class EntsoeCoordinator(DataUpdateCoordinator):
                 for k, v in data.items()
                 if k.date() >= start_date.date() and k.date() <= end_date.date()
             }
+
+        # Update raw_hourprices with the newly fetched data
+        self.raw_hourprices.update(
+            {k: round(v / ENERGY_SCALES[self.energy_scale], 5) for k, v in data.items()}
+        )
+
         return self.parse_hourprices(data)

--- a/custom_components/entsoe/sensor.py
+++ b/custom_components/entsoe/sensor.py
@@ -53,7 +53,7 @@ def sensor_descriptions(
     return (
         EntsoeEntityDescription(
             key="current_price",
-            name="Current electricity market price",
+            name="Current electricity price (all-in)",
             native_unit_of_measurement=f"{currency}/{energy_scale}",
             state_class=SensorStateClass.MEASUREMENT,
             icon="mdi:currency-eur",
@@ -61,8 +61,17 @@ def sensor_descriptions(
             value_fn=lambda coordinator: coordinator.get_current_price(),
         ),
         EntsoeEntityDescription(
+            key="current_spot_price",
+            name="Current electricity spot price",
+            native_unit_of_measurement=f"{currency}/{energy_scale}",
+            state_class=SensorStateClass.MEASUREMENT,
+            icon="mdi:currency-eur",
+            suggested_display_precision=3,
+            value_fn=lambda coordinator: coordinator.get_current_raw_price(),
+        ),
+        EntsoeEntityDescription(
             key="next_hour_price",  # Technically this is the price for the next period, which may be 15 or 60 minutes. Keeping for backwards compatibility.
-            name="Next hour electricity market price",
+            name="Next hour electricity price (all-in)",
             native_unit_of_measurement=f"{currency}/{energy_scale}",
             state_class=SensorStateClass.MEASUREMENT,
             icon="mdi:currency-eur",


### PR DESCRIPTION
This MR adds a new sensor `current_spot_price` that holds the current raw (spot) price. This is the raw price from Entso. It also added `spot_price` to the sensor data that can be used in the graph.

This way it's a bit easier to show the current spot price.

<img width="335" height="645" alt="Screenshot 2026-05-14 at 21 50 41" src="https://github.com/user-attachments/assets/f34e955c-3c05-4907-8eef-7e3313590ce5" />


<img width="1237" height="745" alt="Screenshot 2026-05-14 at 21 51 43" src="https://github.com/user-attachments/assets/610ead12-ef7a-40e3-8841-9a0837846300" />

```
type: custom:apexcharts-card
grid_options:
  columns: full
graph_span: 24h
span:
  start: day
now:
  show: true
  label: Now
header:
  show: true
  title: Stroomprijs vandaag (€/kWh)
series:
  - entity: sensor.dynamische_tarieven_average_electricity_price
    name: Price (spot)
    stroke_width: 2
    float_precision: 3
    type: column
    opacity: 1
    color: ""
    data_generator: |
      return entity.attributes.prices.map((record, index) => {
        return [record.time, record.spot_price];
      });
  - entity: sensor.dynamische_tarieven_average_electricity_price
    name: Price (all-in)
    stroke_width: 2
    float_precision: 3
    type: column
    opacity: 1
    color: ""
    data_generator: |
      return entity.attributes.prices.map((record, index) => {
        return [record.time, record.price];
      });
yaxis:
  - id: Prijs
    decimals: 2

```