### PR TITLE
Fix sensor entity ID domain

### DIFF
--- a/custom_components/entsoe/sensor.py
+++ b/custom_components/entsoe/sensor.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.util import utcnow, slugify
+from homeassistant.util import utcnow
 
 from .utils import bucket_time
 from .const import (
@@ -172,13 +172,10 @@ class EntsoeSensor(CoordinatorEntity, RestoreSensor):
         self.last_update_success = True
 
         if name not in (None, ""):
-            # The Id used for addressing the entity in the ui, recorder history etc.
-            self.entity_id = f"{DOMAIN}.{slugify(name)}_{slugify(description.name)}"
             # unique id in .storage file for ui configuration.
             self._attr_unique_id = f"entsoe.{name}_{description.key}"
             self._attr_name = f"{description.name} ({name})"
         else:
-            self.entity_id = f"{DOMAIN}.{slugify(description.name)}"
             self._attr_unique_id = f"entsoe.{description.key}"
             self._attr_name = f"{description.name}"
 


### PR DESCRIPTION
Fixes #312

EntsoeSensor manually assigns entity IDs using the integration domain (entsoe.*) even though it is a SensorEntity. Home Assistant currently corrects this through the entity registry but logs a deprecation warning; this will stop working in Home Assistant 2027.5.

Remove the manual entity_id assignments and let Home Assistant generate IDs using the sensor platform domain.

The unique_id values remain unchanged, so existing entity-registry IDs, customizations, and history are preserved.